### PR TITLE
This commit fixes weird VS Code + Typescript bug. 

### DIFF
--- a/front/src/app/components/common/load-mask/preview.tsx
+++ b/front/src/app/components/common/load-mask/preview.tsx
@@ -1,7 +1,7 @@
-const React = require('react');
-const LoadMask = require('./index.tsx').LoadMask;
+import * as React from 'react';
+import { LoadMask } from './index';
 
-module.exports = class LoadMaskPreview extends React.Component {
+export class LoadMaskPreview extends React.Component<any> {
     public state = {
         isLoadMaskVisible: false,
     };
@@ -27,4 +27,4 @@ module.exports = class LoadMaskPreview extends React.Component {
             </LoadMask>
         );
     }
-};
+}

--- a/front/src/app/components/common/load-mask/readme.md
+++ b/front/src/app/components/common/load-mask/readme.md
@@ -1,7 +1,7 @@
 Fullscreen load mask
 
 ```js
-const LoadMaskPreview = require('./preview.tsx');
+const { LoadMaskPreview } = require('./preview.tsx');
 
 <LoadMaskPreview delay={5000} />;
 ```
@@ -9,7 +9,7 @@ const LoadMaskPreview = require('./preview.tsx');
 Appearance is debounced
 
 ```js
-const LoadMaskPreview = require('./preview.tsx');
+const { LoadMaskPreview } = require('./preview.tsx');
 
 <LoadMaskPreview delay={200} />;
 ```


### PR DESCRIPTION
`const React = require('react');` - this instruction brakes typescript interpreter in VS Code. After that every class inherited from React.Component doesn't have any component properties (like props). And consequently every tsx tag reports an error: ts2607 JSX element class does not support attributes because it does not have a 'props' property. (#202)